### PR TITLE
for SuSE Linux LX-Brandz support: add network support v.4

### DIFF
--- a/usr/src/lib/brand/lx/zone/lx_boot_zone_suse.ksh
+++ b/usr/src/lib/brand/lx/zone/lx_boot_zone_suse.ksh
@@ -87,7 +87,7 @@ $1 == "physical:" {
     fname = npath "/ifcfg-" $2
     print("# Automatic zone config for interface:", $2) > fname
     print("STARTMODE=auto") >> fname
-    print("BOOTPROTO=dhcp") >> fname
+    print("BOOTPROTO=dhcp4") >> fname
 }
 $1 == "property:" && $2 == "(name=primary,value=\"true\")" {
     print("DHCLIENT_SET_DEFAULT_ROUTE=yes") >> fname


### PR DESCRIPTION
DHCP both version 4 and 6 -> DHCP version 4 only